### PR TITLE
Add stm32 arduino ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: arduino/actions/libraries/compile-examples@master
+            - uses: arduino/compile-sketches@main
               with:
                   fqbn: "stm32duino:STM32F1:genericSTM32F103C"
                   platforms: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+on: ["push"]
+
+jobs:
+    arduino:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: arduino/actions/libraries/compile-examples@master
+              with:
+                  fqbn: "stm32duino:STM32F1:genericSTM32F103C"
+                  platforms: |
+                      - name: "stm32duino:STM32F1"
+                        source-url: "http://dan.drown.org/stm32duino/package_STM32duino_index.json"
+                  sketch-paths: |
+                      - first_launch
+                      - second_launch
+                  libraries: |
+                      - name: MPU6050_tockn
+                      - name: MS5611
+                      - name: SD
+                      # SPI.h and Wire.h seem to be available per default
+                  enable-deltas-report: true


### PR DESCRIPTION
It works for the arduino uno (see https://github.com/codeuniversity/rocket-from-scratch/pull/16/commits/97de30356884ccc2d4119154818e96dd1d6c6272), but ~~stm32 support is blocked by https://github.com/arduino/actions/issues/91.~~ edit: wörks!

The important file is [`.github/workflows/ci.yml`](https://github.com/codeuniversity/rocket-from-scratch/pull/16/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f), the rest under `.github/stm32duino/` is just the vendored board specification.